### PR TITLE
Ignore HTML comments when parsing an HTML string.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -22,6 +22,10 @@ module.exports = function parse(html, options) {
                 inComponent = false;
             }
         }
+        // check if this is a comment tag. if so, just return.
+        if (tag.indexOf('<!--') === 0) {
+            return;
+        }
         var isOpen = tag.charAt(1) !== '/';
         var start = index + tag.length;
         var nextChar = html.charAt(start);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 /*jshint -W030 */
-var tagRE = /<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g;
+var tagRE = /(?:<!--[\S\s]*-->|<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>)/g;
 var parseTag = require('./parse-tag');
 // re-used obj for quick lookups of components
 var empty = Object.create ? Object.create(null) : {};

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 /*jshint -W030 */
-var tagRE = /(?:<!--[\S\s]*-->|<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>)/g;
+var tagRE = /(?:<!--[\S\s]*?-->|<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>)/g;
 var parseTag = require('./parse-tag');
 // re-used obj for quick lookups of components
 var empty = Object.create ? Object.create(null) : {};

--- a/test/parse.js
+++ b/test/parse.js
@@ -366,6 +366,18 @@ test('parse', function (t) {
             { type: 'text', content: 'There' }
         ]
     }], 'should remove text nodes that are nothing but whitespace');
+
+    html = '<!--\n\t<style type="text/css">\n\t\t.header {\n\t\t\tfont-size: 14px;\n\t\t}\n\t</style>\n\n-->\n<div>Hi</div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi'}
+        ]
+    }], 'should ignore HTML comments');
     t.end();
 });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -378,6 +378,24 @@ test('parse', function (t) {
             { type: 'text', content: 'Hi'}
         ]
     }], 'should ignore HTML comments');
+
+    html = '<div>Hi <!-- I\'m a nested comment! with a <span></span> --></div><span><!--test--></span>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi '}
+        ]
+    },{
+        type: 'tag',
+        name: 'span',
+        attrs: {},
+        voidElement: false,
+        children: []
+    }], 'should ignore nested HTML comments');
     t.end();
 });
 


### PR DESCRIPTION
e.g. don't treat any of this as a node:

```
<!-- Here's a comment and some nodes inside:
  <div>I'm not here!</div>
-->
```
