### PR TITLE
Fix void elements

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,25 +1,5 @@
 var attrRE = /([\w-]+)|(['"])(.*?)\2/g;
-
-// create optimized lookup object for
-// void elements as listed here:
-// http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
-var lookup = (Object.create) ? Object.create(null) : {};
-lookup.area = true;
-lookup.base = true;
-lookup.br = true;
-lookup.col = true;
-lookup.embed = true;
-lookup.hr = true;
-lookup.img = true;
-lookup.input = true;
-lookup.keygen = true;
-lookup.link = true;
-lookup.menuitem = true;
-lookup.meta = true;
-lookup.param = true;
-lookup.source = true;
-lookup.track = true;
-lookup.wbr = true;
+var voidElements = require('void-elements');
 
 module.exports = function (tag) {
     var i = 0;
@@ -37,7 +17,7 @@ module.exports = function (tag) {
             key = match;
         } else {
             if (i === 0) {
-                if (lookup[match] || tag.charAt(tag.length - 2) === '/') {
+                if (voidElements[match]) {
                     res.voidElement = true;
                 }
                 res.name = match;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/rayd/html-parse-stringify2/issues"
   },
   "dependencies": {
-    "void-elements": "^1.0.0"
+    "void-elements": "^2.0.1"
   },
   "devDependencies": {
     "jshint": "^2.5.10",


### PR DESCRIPTION
- Upgrade and actually use the `void-elements` module that this package depends on.
- Don't assume it's a void element just because `/` is at the end of the tag, actually use the lookup.
