### PR TITLE
Treat Tags as Single Line

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,4 +1,4 @@
-var attrRE = /([\w-]+)|(['"])(.*?)\2/g;
+var attrRE = /([\w-]+)|(['"])([.\s\S]*?)\2/g;
 
 // create optimized lookup object for
 // void elements as listed here:

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -66,6 +66,19 @@ test('parseTag', function (t) {
         voidElement: false,
         children: []
     });
+    
+    tag = '<textarea placeholder=\'Hey Usher, \n\nAre these modals for real?!\' class=\'placeholder-value\'>';
+
+    t.deepEqual(parseTag(tag), {
+        type: 'tag',
+        attrs: {
+            placeholder: 'Hey Usher, \n\nAre these modals for real?!',
+            class: 'placeholder-value'
+        },
+        name: 'textarea',
+        voidElement: false,
+        children: []
+    });
 
     t.end();
 });


### PR DESCRIPTION
- Treat `tag` values as single-line in `lib/parse-tag.js`
- Tests to ensure correctness

Prevents the following from happening...

<img width="811" alt="screen shot 2017-04-19 at 4 04 30 pm" src="https://cloud.githubusercontent.com/assets/1547447/25199779/f5dd9d94-2519-11e7-8868-fbefefb52a7e.png">
