### PR TITLE
add ignoreCollapse options

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -32,7 +32,7 @@ module.exports = function (tag) {
                 }
                 res.name = match;
             } else {
-                res.attrs[key] = match.replace(/^['"]|['"]$/g, '');
+                res.attrs[key] = match; // .replace(/^['"]|['"]$/g, '');
                 key=undefined;
             }
         }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,14 +4,14 @@ var parseTag = require('./parse-tag');
 // re-used obj for quick lookups of components
 var empty = Object.create ? Object.create(null) : {};
 // common logic for pushing a child node onto a list
-function pushTextNode(list, html, level, start, ignoreWhitespace) {
+function pushTextNode(list, html, level, start, ignoreWhitespace, ignoreCollapse) {
     // calculate correct end of the content slice in case there's
     // no tag after the text node.
     var end = html.indexOf('<', start);
     var content = html.slice(start, end === -1 ? undefined : end);
     // if a node is nothing but whitespace, collapse it as the spec states:
     // https://www.w3.org/TR/html4/struct/text.html#h-9.1
-    if (/^\s*$/.test(content)) {
+    if (!ignoreCollapse && /^\s*$/.test(content)) {
         content = ' ';
     }
     // don't add whitespace-only text nodes if they would be trailing text nodes
@@ -61,7 +61,7 @@ module.exports = function parse(html, options) {
             }
 
             if (!current.voidElement && !inComponent && nextChar && nextChar !== '<') {
-                pushTextNode(current.children, html, level, start, options.ignoreWhitespace);
+                pushTextNode(current.children, html, level, start, options.ignoreWhitespace, options.ignoreCollapse);
             }
 
             byTag[current.tagName] = current;
@@ -89,14 +89,14 @@ module.exports = function parse(html, options) {
                 // if we're at the root, push a base text node. otherwise add as
                 // a child to the current node.
                 parent = level === -1 ? result : arr[level].children;
-                pushTextNode(parent, html, level, start, options.ignoreWhitespace);
+                pushTextNode(parent, html, level, start, options.ignoreWhitespace, options.ignoreCollapse);
             }
         }
     });
 
     // If the "html" passed isn't actually html, add it as a text node.
     if (!result.length && html.length) {
-        pushTextNode(result, html, 0, 0, options.ignoreWhitespace);
+        pushTextNode(result, html, 0, 0, options.ignoreWhitespace, options.ignoreCollapse);
     }
 
     return result;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,7 +1,7 @@
 function attrString(attrs) {
     var buff = [];
     for (var key in attrs) {
-        buff.push(key + '="' + attrs[key] + '"');
+        buff.push(key + '=' + attrs[key]);
     }
     if (!buff.length) {
         return '';


### PR DESCRIPTION
Based on the specification this module collapses nodes only having whitespace. While this is correct there are cases you want to persist those. We built a simple syntax highlighting for i18n formats based on this module where we overlay a div over a text input field - but having this collapsing the content gets out of sync -> therefore, this option would help:

```js
// content
<p>
Some
</p>
<p>
Strange Value2
</p>

// ends in (without this option)
<p>
Some
</p> <p>
Strange Value2
</p>
```