### PR TITLE
fix: multi close tag will make level < -1

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -81,7 +81,7 @@ module.exports = function parse(html, options) {
         }
 
         if (isComment || !isOpen || current.voidElement) {
-            if (!isComment) {
+            if (!isComment && level > -1) {
                 level--;
             }
             if (!inComponent && nextChar !== '<' && nextChar) {


### PR DESCRIPTION
when html has multi close tags, It will lead to errors；
case like: <div>it just a test </br></br> </div>；

error code source：
L91： parent = level === -1 ? result : arr[level].children;
