### PR TITLE
fix: illegal close tag

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -81,6 +81,17 @@ module.exports = function parse(html, options) {
         }
 
         if (isComment || !isOpen || current.voidElement) {
+            // if it's close tag and it isn't current tag's close tag, ignore the illegal tag;
+            // case: <div> wow </span> </div> => <div> wow </div>
+            if (!isOpen && current.name) {
+                var curTagName = current.name;
+                var length = curTagName.length;
+                for (var m = 0; m < length; m++) {
+                    if (tag.charAt(2 + m) !== curTagName.charAt(m)) {
+                        return;
+                    }
+                }
+            }
             if (!isComment) {
                 level--;
             }


### PR DESCRIPTION
if it's close tag and it isn't current tag's close tag, ignore the illegal tag;
case: <div> wow </span> </div> => <div> wow </div>