### PR TITLE
fix CVE-2021-23346 vulnerability

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 /*jshint -W030 */
-var tagRE = /(?:<!--[\S\s]*?-->|<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>)/g;
+var tagRE = /(?:<!--[\S\s]*?-->|<(?:"[^"]*"|'[^']*'|[^'">])+>)/g;
 var parseTag = require('./parse-tag');
 // re-used obj for quick lookups of components
 var empty = Object.create ? Object.create(null) : {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-parse-stringify2",
   "description": "Parses well-formed HTML (meaning all tags closed) into an AST and back. quickly.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Ray Di Ciaccio <ray.diciaccio@gmail.com>",
   "bugs": {
     "url": "https://github.com/rayd/html-parse-stringify2/issues"

--- a/test/parse.js
+++ b/test/parse.js
@@ -482,6 +482,21 @@ test('parse', function (t) {
     t.end();
 });
 
+test('ReDoS vulnerability fix (CVE-2021-23346)', function (t) {
+    // Test malicious inputs that would cause catastrophic backtracking
+    // with the vulnerable regex pattern
+    var maliciousInput1 = '<!\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'!';
+    var maliciousInput2 = '<!""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""!';
+    
+    var start = Date.now();
+    HTML.parse(maliciousInput1);
+    HTML.parse(maliciousInput2);
+    var duration = Date.now() - start;
+    
+    t.ok(duration < 100, 'should not hang on ReDoS input (took ' + duration + 'ms)');
+    t.end();
+});
+
 test('simple speed sanity check', function (t) {
     var i = 100000;
     var groupSize = 1000;


### PR DESCRIPTION
This PR fixes the vulnerability reported here: https://github.com/advisories/GHSA-545q-3fg6-48m7, based on an example of a PR solving the vulnerability in the lib that is the base lib for this one:
https://github.com/HenrikJoreteg/html-parse-stringify/commit/c7274a48e59c92b2b7e906fedf9065159e73fe12 

This PR also bumps the version so we can publish to npm, after merging to main branch.

I was facing some issues to run tests from the npm script reference, I think due to be using a newer node version, to run the tests I used tape bin ref directly: `node_modules/.bin/tape test/` 